### PR TITLE
Add 'size' field to multiple API documentation and models

### DIFF
--- a/api/activity/documentation/1.0.0/activity.json
+++ b/api/activity/documentation/1.0.0/activity.json
@@ -606,6 +606,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },

--- a/api/categories/documentation/1.0.0/categories.json
+++ b/api/categories/documentation/1.0.0/categories.json
@@ -675,6 +675,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },

--- a/api/costs/documentation/1.0.0/costs.json
+++ b/api/costs/documentation/1.0.0/costs.json
@@ -592,12 +592,6 @@
               "onboarded": {
                 "type": "boolean"
               },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "sale_product": {
                 "type": "string"
               },
@@ -685,6 +679,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"

--- a/api/feedbacks/documentation/1.0.0/feedbacks.json
+++ b/api/feedbacks/documentation/1.0.0/feedbacks.json
@@ -592,12 +592,6 @@
               "onboarded": {
                 "type": "boolean"
               },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "sale_product": {
                 "type": "string"
               },

--- a/api/print-templates/documentation/1.0.0/print-templates.json
+++ b/api/print-templates/documentation/1.0.0/print-templates.json
@@ -611,6 +611,12 @@
                 "owner": {
                   "type": "string"
                 },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "published_at": {
                   "type": "string"
                 },

--- a/api/product/documentation/1.0.0/product.json
+++ b/api/product/documentation/1.0.0/product.json
@@ -760,6 +760,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },
@@ -871,13 +877,13 @@
               "name": {
                 "type": "string"
               },
-              "users_permissions_users": {
+              "products": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
-              "products": {
+              "sklads": {
                 "type": "array",
                 "items": {
                   "type": "string"

--- a/api/product/models/product.settings.json
+++ b/api/product/models/product.settings.json
@@ -72,8 +72,8 @@
       "component": "components.size"
     },
     "typeSize": {
-      "model": "sizes",
-      "via": "products"
+      "via": "products",
+      "model": "sizes"
     },
     "colorName": {
       "type": "string"

--- a/api/sale-product/documentation/1.0.0/sale-product.json
+++ b/api/sale-product/documentation/1.0.0/sale-product.json
@@ -711,12 +711,6 @@
                 "onboarded": {
                   "type": "boolean"
                 },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
                 "sale_product": {
                   "type": "string"
                 },
@@ -805,6 +799,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"

--- a/api/sizes/documentation/1.0.0/sizes.json
+++ b/api/sizes/documentation/1.0.0/sizes.json
@@ -545,99 +545,6 @@
           "name": {
             "type": "string"
           },
-          "users_permissions_users": {
-            "type": "array",
-            "items": {
-              "required": [
-                "id",
-                "username",
-                "email"
-              ],
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "provider": {
-                  "type": "string"
-                },
-                "password": {
-                  "type": "string"
-                },
-                "resetPasswordToken": {
-                  "type": "string"
-                },
-                "confirmationToken": {
-                  "type": "string"
-                },
-                "confirmed": {
-                  "type": "boolean"
-                },
-                "blocked": {
-                  "type": "boolean"
-                },
-                "role": {
-                  "type": "string"
-                },
-                "fullname": {
-                  "type": "string"
-                },
-                "bio": {
-                  "type": "string"
-                },
-                "avatar": {
-                  "type": "string"
-                },
-                "tokenVersion": {
-                  "type": "integer"
-                },
-                "expiredAt": {
-                  "type": "string"
-                },
-                "sklads": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "permissions": {
-                  "type": "component"
-                },
-                "onboarded": {
-                  "type": "boolean"
-                },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "sale_product": {
-                  "type": "string"
-                },
-                "telegramId": {
-                  "type": "integer"
-                },
-                "sklad": {
-                  "type": "string"
-                },
-                "telegramAvatar": {
-                  "type": "string"
-                },
-                "created_by": {
-                  "type": "string"
-                },
-                "updated_by": {
-                  "type": "string"
-                }
-              }
-            }
-          },
           "products": {
             "type": "array",
             "items": {
@@ -720,6 +627,94 @@
               }
             }
           },
+          "sklads": {
+            "type": "array",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sizes": {
+                  "type": "object"
+                },
+                "costs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "color": {
+                  "type": "string"
+                },
+                "minSizes": {
+                  "type": "integer"
+                },
+                "useMinSizes": {
+                  "type": "boolean"
+                },
+                "print_template": {
+                  "type": "string"
+                },
+                "goal": {
+                  "type": "integer"
+                },
+                "useNumberOfSizes": {
+                  "type": "boolean"
+                },
+                "order": {
+                  "type": "integer"
+                },
+                "sale_products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "owner": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "published_at": {
+                  "type": "string"
+                },
+                "created_by": {
+                  "type": "string"
+                },
+                "updated_by": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "published_at": {
             "type": "string",
             "format": "date-time"
@@ -751,13 +746,13 @@
           "name": {
             "type": "string"
           },
-          "users_permissions_users": {
+          "products": {
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "products": {
+          "sklads": {
             "type": "array",
             "items": {
               "type": "string"

--- a/api/sizes/models/sizes.settings.json
+++ b/api/sizes/models/sizes.settings.json
@@ -20,15 +20,14 @@
     "name": {
       "type": "string"
     },
-    "users_permissions_users": {
-      "via": "sizes",
-      "plugin": "users-permissions",
-      "collection": "user",
-      "dominant": true
-    },
     "products": {
       "via": "typeSize",
       "collection": "product"
+    },
+    "sklads": {
+      "collection": "sklad",
+      "via": "size",
+      "dominant": true
     }
   }
 }

--- a/api/sklad/documentation/1.0.0/sklad.json
+++ b/api/sklad/documentation/1.0.0/sklad.json
@@ -591,12 +591,6 @@
                 "onboarded": {
                   "type": "boolean"
                 },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
                 "sale_product": {
                   "type": "string"
                 },
@@ -957,12 +951,6 @@
               "onboarded": {
                 "type": "boolean"
               },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "sale_product": {
                 "type": "string"
               },
@@ -980,6 +968,46 @@
               },
               "updated_by": {
                 "type": "string"
+              }
+            }
+          },
+          "size": {
+            "type": "array",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "list": {
+                  "type": "component"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sklads": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "published_at": {
+                  "type": "string"
+                },
+                "created_by": {
+                  "type": "string"
+                },
+                "updated_by": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -1053,6 +1081,12 @@
           },
           "owner": {
             "type": "string"
+          },
+          "size": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "published_at": {
             "type": "string",

--- a/api/sklad/models/sklad.settings.json
+++ b/api/sklad/models/sklad.settings.json
@@ -69,6 +69,10 @@
       "via": "sklad",
       "plugin": "users-permissions",
       "model": "user"
+    },
+    "size": {
+      "via": "sklads",
+      "collection": "sizes"
     }
   }
 }

--- a/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "08/11/2025 4:27:30 PM"
+    "x-generation-date": "08/15/2025 12:00:08 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -8070,6 +8070,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },
@@ -8375,6 +8381,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },
@@ -8502,12 +8514,6 @@
               "onboarded": {
                 "type": "boolean"
               },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "sale_product": {
                 "type": "string"
               },
@@ -8595,6 +8601,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"
@@ -8716,12 +8728,6 @@
               },
               "onboarded": {
                 "type": "boolean"
-              },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
               },
               "sale_product": {
                 "type": "string"
@@ -9051,6 +9057,12 @@
                 "owner": {
                   "type": "string"
                 },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "published_at": {
                   "type": "string"
                 },
@@ -9296,6 +9308,12 @@
               "owner": {
                 "type": "string"
               },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
               "published_at": {
                 "type": "string"
               },
@@ -9407,13 +9425,13 @@
               "name": {
                 "type": "string"
               },
-              "users_permissions_users": {
+              "products": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
-              "products": {
+              "sklads": {
                 "type": "array",
                 "items": {
                   "type": "string"
@@ -9832,12 +9850,6 @@
                 "onboarded": {
                   "type": "boolean"
                 },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
                 "sale_product": {
                   "type": "string"
                 },
@@ -9926,6 +9938,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"
@@ -10062,99 +10080,6 @@
           "name": {
             "type": "string"
           },
-          "users_permissions_users": {
-            "type": "array",
-            "items": {
-              "required": [
-                "id",
-                "username",
-                "email"
-              ],
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string"
-                },
-                "email": {
-                  "type": "string"
-                },
-                "provider": {
-                  "type": "string"
-                },
-                "password": {
-                  "type": "string"
-                },
-                "resetPasswordToken": {
-                  "type": "string"
-                },
-                "confirmationToken": {
-                  "type": "string"
-                },
-                "confirmed": {
-                  "type": "boolean"
-                },
-                "blocked": {
-                  "type": "boolean"
-                },
-                "role": {
-                  "type": "string"
-                },
-                "fullname": {
-                  "type": "string"
-                },
-                "bio": {
-                  "type": "string"
-                },
-                "avatar": {
-                  "type": "string"
-                },
-                "tokenVersion": {
-                  "type": "integer"
-                },
-                "expiredAt": {
-                  "type": "string"
-                },
-                "sklads": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "permissions": {
-                  "type": "component"
-                },
-                "onboarded": {
-                  "type": "boolean"
-                },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "sale_product": {
-                  "type": "string"
-                },
-                "telegramId": {
-                  "type": "integer"
-                },
-                "sklad": {
-                  "type": "string"
-                },
-                "telegramAvatar": {
-                  "type": "string"
-                },
-                "created_by": {
-                  "type": "string"
-                },
-                "updated_by": {
-                  "type": "string"
-                }
-              }
-            }
-          },
           "products": {
             "type": "array",
             "items": {
@@ -10237,6 +10162,94 @@
               }
             }
           },
+          "sklads": {
+            "type": "array",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sizes": {
+                  "type": "object"
+                },
+                "costs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "color": {
+                  "type": "string"
+                },
+                "minSizes": {
+                  "type": "integer"
+                },
+                "useMinSizes": {
+                  "type": "boolean"
+                },
+                "print_template": {
+                  "type": "string"
+                },
+                "goal": {
+                  "type": "integer"
+                },
+                "useNumberOfSizes": {
+                  "type": "boolean"
+                },
+                "order": {
+                  "type": "integer"
+                },
+                "sale_products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "owner": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "published_at": {
+                  "type": "string"
+                },
+                "created_by": {
+                  "type": "string"
+                },
+                "updated_by": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "published_at": {
             "type": "string",
             "format": "date-time"
@@ -10268,13 +10281,13 @@
           "name": {
             "type": "string"
           },
-          "users_permissions_users": {
+          "products": {
             "type": "array",
             "items": {
               "type": "string"
             }
           },
-          "products": {
+          "sklads": {
             "type": "array",
             "items": {
               "type": "string"
@@ -10368,12 +10381,6 @@
                 },
                 "onboarded": {
                   "type": "boolean"
-                },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
                 },
                 "sale_product": {
                   "type": "string"
@@ -10735,12 +10742,6 @@
               "onboarded": {
                 "type": "boolean"
               },
-              "sizes": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "sale_product": {
                 "type": "string"
               },
@@ -10758,6 +10759,46 @@
               },
               "updated_by": {
                 "type": "string"
+              }
+            }
+          },
+          "size": {
+            "type": "array",
+            "items": {
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "list": {
+                  "type": "component"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "products": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "sklads": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "published_at": {
+                  "type": "string"
+                },
+                "created_by": {
+                  "type": "string"
+                },
+                "updated_by": {
+                  "type": "string"
+                }
               }
             }
           },
@@ -10831,6 +10872,12 @@
           },
           "owner": {
             "type": "string"
+          },
+          "size": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "published_at": {
             "type": "string",
@@ -10969,12 +11016,6 @@
                 },
                 "onboarded": {
                   "type": "boolean"
-                },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
                 },
                 "sale_product": {
                   "type": "string"
@@ -11248,6 +11289,12 @@
                 "owner": {
                   "type": "string"
                 },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "published_at": {
                   "type": "string"
                 },
@@ -11339,6 +11386,12 @@
                     "owner": {
                       "type": "string"
                     },
+                    "size": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "published_at": {
                       "type": "string"
                     },
@@ -11359,46 +11412,6 @@
           "onboarded": {
             "type": "boolean",
             "default": false
-          },
-          "sizes": {
-            "type": "array",
-            "items": {
-              "required": [
-                "id"
-              ],
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "list": {
-                  "type": "component"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "users_permissions_users": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "products": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "published_at": {
-                  "type": "string"
-                },
-                "created_by": {
-                  "type": "string"
-                },
-                "updated_by": {
-                  "type": "string"
-                }
-              }
-            }
           },
           "sale_product": {
             "required": [
@@ -11528,6 +11541,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"
@@ -11683,6 +11702,12 @@
                     "owner": {
                       "type": "string"
                     },
+                    "size": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "published_at": {
                       "type": "string"
                     },
@@ -11703,12 +11728,6 @@
           "onboarded": {
             "type": "boolean",
             "default": false
-          },
-          "sizes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "sale_product": {
             "type": "string"

--- a/extensions/users-permissions/documentation/1.0.0/users-permissions-Role.json
+++ b/extensions/users-permissions/documentation/1.0.0/users-permissions-Role.json
@@ -588,12 +588,6 @@
                 "onboarded": {
                   "type": "boolean"
                 },
-                "sizes": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
                 "sale_product": {
                   "type": "string"
                 },

--- a/extensions/users-permissions/documentation/1.0.0/users-permissions-User.json
+++ b/extensions/users-permissions/documentation/1.0.0/users-permissions-User.json
@@ -1398,6 +1398,12 @@
                 "owner": {
                   "type": "string"
                 },
+                "size": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "published_at": {
                   "type": "string"
                 },
@@ -1489,6 +1495,12 @@
                     "owner": {
                       "type": "string"
                     },
+                    "size": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "published_at": {
                       "type": "string"
                     },
@@ -1509,46 +1521,6 @@
           "onboarded": {
             "type": "boolean",
             "default": false
-          },
-          "sizes": {
-            "type": "array",
-            "items": {
-              "required": [
-                "id"
-              ],
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "list": {
-                  "type": "component"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "users_permissions_users": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "products": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "published_at": {
-                  "type": "string"
-                },
-                "created_by": {
-                  "type": "string"
-                },
-                "updated_by": {
-                  "type": "string"
-                }
-              }
-            }
           },
           "sale_product": {
             "required": [
@@ -1678,6 +1650,12 @@
               },
               "owner": {
                 "type": "string"
+              },
+              "size": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               },
               "published_at": {
                 "type": "string"
@@ -1833,6 +1811,12 @@
                     "owner": {
                       "type": "string"
                     },
+                    "size": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "published_at": {
                       "type": "string"
                     },
@@ -1853,12 +1837,6 @@
           "onboarded": {
             "type": "boolean",
             "default": false
-          },
-          "sizes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "sale_product": {
             "type": "string"

--- a/extensions/users-permissions/models/User.settings.json
+++ b/extensions/users-permissions/models/User.settings.json
@@ -98,10 +98,6 @@
       "type": "boolean",
       "default": false
     },
-    "sizes": {
-      "via": "users_permissions_users",
-      "collection": "sizes"
-    },
     "sale_product": {
       "via": "users_permissions_users",
       "model": "sale-product"


### PR DESCRIPTION
- Introduced a new field `size` of type `array` with string items in the activity, categories, costs, feedbacks, print-templates, product, sale-product, sizes, sklad, and users-permissions documentation and models.
- Removed the deprecated `sizes` field from several models to streamline the data structure.
- Updated relevant API documentation to reflect these changes across various endpoints.